### PR TITLE
Remove support for mis-encoded PKCS#8 DSA keys.

### DIFF
--- a/src/crypto/evp/p_dsa_asn1.c
+++ b/src/crypto/evp/p_dsa_asn1.c
@@ -168,64 +168,20 @@ static int dsa_priv_decode(EVP_PKEY *pkey, PKCS8_PRIV_KEY_INFO *p8) {
   /* In PKCS#8 DSA: you just get a private key integer and parameters in the
    * AlgorithmIdentifier the pubkey must be recalculated. */
 
-  STACK_OF(ASN1_TYPE) *ndsa = NULL;
   DSA *dsa = NULL;
 
   if (!PKCS8_pkey_get0(NULL, &p, &pklen, &palg, p8)) {
     return 0;
   }
-  X509_ALGOR_get0(NULL, &ptype, &pval, palg);
-
-  /* Check for broken DSA PKCS#8, UGH! */
-  if (*p == (V_ASN1_SEQUENCE | V_ASN1_CONSTRUCTED)) {
-    ASN1_TYPE *t1, *t2;
-    ndsa = d2i_ASN1_SEQUENCE_ANY(NULL, &p, pklen);
-    if (ndsa == NULL) {
-      goto decerr;
-    }
-    if (sk_ASN1_TYPE_num(ndsa) != 2) {
-      goto decerr;
-    }
-
-    /* Handle Two broken types:
-     * SEQUENCE {parameters, priv_key}
-     * SEQUENCE {pub_key, priv_key}. */
-
-    t1 = sk_ASN1_TYPE_value(ndsa, 0);
-    t2 = sk_ASN1_TYPE_value(ndsa, 1);
-    if (t1->type == V_ASN1_SEQUENCE) {
-      p8->broken = PKCS8_EMBEDDED_PARAM;
-      pval = t1->value.ptr;
-    } else if (ptype == V_ASN1_SEQUENCE) {
-      p8->broken = PKCS8_NS_DB;
-    } else {
-      goto decerr;
-    }
-
-    if (t2->type != V_ASN1_INTEGER) {
-      goto decerr;
-    }
-
-    privkey = t2->value.integer;
-  } else {
-    const uint8_t *q = p;
-    privkey = d2i_ASN1_INTEGER(NULL, &p, pklen);
-    if (privkey == NULL) {
-      goto decerr;
-    }
-    if (privkey->type == V_ASN1_NEG_INTEGER) {
-      p8->broken = PKCS8_NEG_PRIVKEY;
-      ASN1_INTEGER_free(privkey);
-      privkey = d2i_ASN1_UINTEGER(NULL, &q, pklen);
-      if (privkey == NULL) {
-        goto decerr;
-      }
-    }
-    if (ptype != V_ASN1_SEQUENCE) {
-      goto decerr;
-    }
+  privkey = d2i_ASN1_INTEGER(NULL, &p, pklen);
+  if (privkey == NULL || privkey->type == V_ASN1_NEG_INTEGER) {
+    goto decerr;
   }
 
+  X509_ALGOR_get0(NULL, &ptype, &pval, palg);
+  if (ptype != V_ASN1_SEQUENCE) {
+    goto decerr;
+  }
   pstr = pval;
   pm = pstr->data;
   pmlen = pstr->length;
@@ -258,7 +214,6 @@ static int dsa_priv_decode(EVP_PKEY *pkey, PKCS8_PRIV_KEY_INFO *p8) {
 
   EVP_PKEY_assign_DSA(pkey, dsa);
   BN_CTX_free(ctx);
-  sk_ASN1_TYPE_pop_free(ndsa, ASN1_TYPE_free);
   ASN1_INTEGER_free(privkey);
 
   return 1;
@@ -269,7 +224,6 @@ decerr:
 dsaerr:
   BN_CTX_free(ctx);
   ASN1_INTEGER_free(privkey);
-  sk_ASN1_TYPE_pop_free(ndsa, ASN1_TYPE_free);
   DSA_free(dsa);
   return 0;
 }


### PR DESCRIPTION
Previously, OpenSSL supported many different DSA PKCS#8 encodings. Only
support the standard format. One of the workaround formats (SEQUENCE of
private key and public key) seems to be a workaround for an old Netscape
bug. From inspection, NSS seems to have fixed this from the first open
source commit.

(cherry-picked from 440f1037716eca16f203edb8f03d4a59c92ae0cc)

Bug: 27449871
Change-Id: I1e097b675145954b4d7a0bed8733e5a25c25fd8e
Reviewed-on: https://boringssl-review.googlesource.com/7074
Reviewed-by: Adam Langley agl@google.com
